### PR TITLE
Added launcher script and fasta support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .snakemake/
+config/
 ignore
+stashlist.txt
+*RData

--- a/serovar_detector.py
+++ b/serovar_detector.py
@@ -1,0 +1,127 @@
+import argparse
+import os
+import sys
+import yaml
+import glob
+import subprocess
+
+def parse_arguments():
+  parser = argparse.ArgumentParser(description = "Screen assemblies for junction sequences in order to characterize specific plasmid markers")
+  parser.add_argument("-r", metavar = "--reads_dir", dest = "reads_dir", help = "Input path to reads directory", required = True)
+  parser.add_argument("-a", metavar = "--assembly_dir", dest = "assembly_dir", help = "Input path to assembly directory", required = True)
+  parser.add_argument("-D", metavar = "--database", dest = "database", help = "Path and prefix to kmer-aligner database", required = True)
+  parser.add_argument("-T", metavar = "--theshold", dest = "threshold", help = "Cutoff threshold of match coverage and identity. Ignore threshold by setting to 0 or False. (Default 98)", default = 98)
+  parser.add_argument("-m", dest = "metadata", help = "Include or generate metadata sheet. Metadata sheet will be reads from/generated in the output directory. (Default False)", action = "store_true")
+  parser.add_argument("-o", metavar = "--outdir", dest = "outdir", help = "Output path to Results and Temporary files directory", required = True)
+  parser.add_argument("-M", dest = "multithreading", help = "Enable multithreading during kmer alignment, use for huge samples only. (Default False)", action = "store_true")
+  parser.add_argument("-k", dest = "keep_config", help = "Preserve configuration file and exit pipeline for debugging purposes. (Default False)", action = "store_true")
+  parser.add_argument("-t", metavar = "--threads", dest = "threads", help = "Number of threads to allocate for the pipeline. (Default 1)", default = 1)
+  parser.add_argument("-F", dest = "force", help = "Force rerun of all tasks in pipeline. (Default False)", action = "store_true")
+  parser.add_argument("-S", dest = "skipmake", help = "Skip Snakemake for requirering manual run of Snakemake. Config file will be generated.", action = "store_true")
+  parser.add_argument("-n", dest = "dry_run", help = "Perform a dry run with Snakemake to see jobs but without executing them. (Default False)", action = "store_true")
+  parser.add_argument("-d", dest = "debug", help = "Enable debug mode, stores snakemake object for inspection in R. (Default False)", action = "store_true")
+
+  return(parser.parse_args())
+
+
+def validate_snakemake(debug):
+  here = os.listdir('.')
+  workflow_here = 'workflow' in os.listdir('.')
+
+  if (workflow_here):
+    snakefile_here = "Snakefile" in os.listdir('workflow')
+
+    if snakefile_here and debug:
+      print("Snakefile detected")
+    elif not snakefile_here:
+      print('Error no Snakefile detected in workflow directory. Software is properbly corrupt, consider redownloading.')
+      sys.exit(1)
+  else:
+    print('No workflow directory detected, are you sure you are running the script from the software folder?')
+    sys.exit(1)
+
+
+def generate_configfile(reads_dir, assembly_dir, database, threshold, metadata, outdir, multithreading, threads, debug, keep_config, skipmake):
+  # Define config file
+  config_file = "config/config.yaml"
+  
+  # Check for existing config file
+  if not os.path.isfile(config_file):
+    config_dir = os.path.dirname(config_file)
+    
+    # Check for existing config dir
+    if not os.path.isdir(config_dir):
+      print("No config dir detected, creating directory.")
+      os.mkdir(config_dir)
+  elif keep_config and not skipmake:
+    print("--keep_config is set to true, exiting!")
+    sys.exit(0)
+
+  # Directing full paths
+  reads_dir_path = os.path.abspath(reads_dir).rstrip("/")
+  assembly_dir_path = os.path.abspath(assembly_dir).rstrip("/")
+  out_path = os.path.abspath(outdir).rstrip("/")
+  
+  config = {"reads_dir" : reads_dir_path, "assembly_dir" : assembly_dir_path, "database" : database, "threshold" : threshold,  "outdir" : out_path, "multithreading" : multithreading, "debug" : debug}
+
+  with open(config_file, "w") as config_yaml:
+    yaml.dump(config, config_yaml)
+
+def initialize_metadata(outdir):
+  metadata_file = "%s/metadata.tsv" %outdir
+  metadata_exists = os.path.isfile(metadata_file)
+  if not metadata_exists:
+    outdir_exists = os.path.isdir(outdir)
+    if not outdir_exists:
+      os.makedirs(outdir)
+    print("Generating metadata sheet at: %s" %metadata_file)
+    with open(metadata_file, "w") as metadata:
+      pass
+    metadata_exists = os.path.isfile(metadata_file)
+  
+  return(metadata_exists)
+
+# Derrive arguments
+args = parse_arguments()
+
+reads_dir = args.reads_dir
+assembly_dir = args.assembly_dir
+database = args.database
+threshold = args.threshold
+metadata = args.metadata
+outdir = args.outdir
+multithreading = args.multithreading
+keep_config = args.keep_config
+threads = args.threads
+force = args.force
+skipmake = args.skipmake
+dry_run = args.dry_run
+debug = args.debug
+
+# Validate snakemake structure
+validate_snakemake(debug)
+
+# Prepare config file for snakemake
+generate_configfile(reads_dir, assembly_dir, database, threshold, metadata, outdir, multithreading, threads, debug, keep_config, skipmake)
+
+# Preparing optional metadata sheet
+if metadata:
+  initialize_metadata(outdir)
+
+if skipmake:
+  print("Warning: Skipping Snakemake!")
+else:
+  snake_args = ""
+  if force:
+    snake_args += " -F "
+  if dry_run:
+    snake_args += " -n "
+  if metadata:
+    snake_args += " all --forcerun metadata "
+
+  snakemake_cmd = "snakemake --use-conda --cores %s%s" %(threads, snake_args) 
+  if debug:
+    print("Running command: %s" %snakemake_cmd)
+
+  subprocess.Popen(snakemake_cmd, shell = True).wait()
+

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -8,46 +8,47 @@ from os.path import basename
 configfile: "config/config.yaml"
 
 database = config["database"]
-sample_dir = config["sample_dir"]
+assembly_dir = config["assembly_dir"]
+reads_dir = config["reads_dir"]
 outdir = config["outdir"]
 
-threshold_id = config["threshold_id"]
-threshold_cov = config["threshold_cov"]
+threshold = config["threshold"]
 
 debug = config["debug"]
 
-mates = glob(pathname = "%s/*.fastq.gz" %sample_dir)
+if reads_dir is not None:
+	mates = glob(pathname = "%s/*.fastq.gz" %reads_dir)
+else:
+	reads_dir = list()
+	mates = list()
 
-samples = {sub("_R\d[_\d+]*.fastq.gz", "", fn) for fn in [basename(mt) for mt in mates]}
+if assembly_dir is not None:
+	assemblies = glob(pathname = "%s/*.fasta" %assembly_dir)
+else:
+	assembly_dir = list()
+	assemblies = list()
 
-if len(samples) < 1:
-	sys.exit("fastq.gz files are missing!")
+sample_reads = {sub("_R\d[_\d+]*.fastq.gz", "", fn) for fn in [basename(mt) for mt in mates]}
+sample_assemblies = {sub(".fasta", "", fn) for fn in [basename(ass) for ass in assemblies]}
+
+#species = basename(database).replace("_", " ") #
 
 metadata_file = "%s/metadata.tsv" %outdir
-if not os.path.isfile(metadata_file):
-	metadata_file = None
-
-species = basename(database).replace("_", " ") #
 
 rule all:
 	input:
-		serovar = "%s/Results/serovar.tsv" %outdir
+		serovar = "%s/serovar.tsv" %outdir
 
 
-rule init:
-        output:
-                temp("%s/init.tmp" %outdir)
-        shell:
-                "mkdir -p %s && touch {output}" %outdir
 
 
 rule metadata:
-	input:
-		rules.init.output
+	priority:
+		1
 	output:
 		metadata_file
 	run:
-		sample_list = ["Sample"] + list(samples)
+		sample_list = ["Sample"] + list(sample_reads, sample_assemblies)
 		with open(metadata_file, "w", newline = "\n") as meta_file:
 			meta_output = csv.writer(meta_file, delimiter = "\t")
 			for line in sample_list:

--- a/workflow/rules/detect_serovars.smk
+++ b/workflow/rules/detect_serovars.smk
@@ -1,7 +1,6 @@
-rule detect_capsules:
+rule detect_assembly_capsules:
 	input:
-		mate1 = "%s/{sample}_R1.fastq.gz" %sample_dir,
-		mate2 = "%s/{sample}_R2.fastq.gz" %sample_dir
+		assemblies = "%s/{sample}.fasta" %assembly_dir
 	params:
 		db = database,
 		prefix  = "%s/kma/{sample}/{sample}" %outdir
@@ -10,9 +9,40 @@ rule detect_capsules:
 		res_file = "%s/kma/{sample}/{sample}.res" %outdir
 	conda:
 		"../envs/kma.yaml"
+	threads:
+		1
+	message:
+		"""
+                mkdir -p {output.kma_dir}
+                kma -i {input.assemblies} -o {params.prefix} -t_db {params.db} -t {threads}
+                """
 	shell:
 		"""
 		mkdir -p {output.kma_dir}
-		#kma -ipe {input.mate1} {input.mate2} -o {params.prefix} -t_db {params.db} -1t1 -dense -ref_fsa -cge -ef -t {threads}
+		kma -i {input.assemblies} -o {params.prefix} -t_db {params.db} -t {threads}
+		"""
+
+rule detect_reads_capsules:
+	input:
+		mate1 = "%s/{sample}_R1.fastq.gz" %reads_dir,
+		mate2 = "%s/{sample}_R2.fastq.gz" %reads_dir
+	params:
+		db = database,
+		prefix  = "%s/kma/{sample}/{sample}" %outdir
+	output:
+		kma_dir = temp(directory("%s/kma/{sample}/" %outdir)),
+		res_file = "%s/kma/{sample}/{sample}.res" %outdir
+	conda:
+		"../envs/kma.yaml"
+	threads:
+		1
+	message:
+		"""
+                mkdir -p {output.kma_dir}
+                kma -ipe {input.mate1} {input.mate2} -o {params.prefix} -t_db {params.db} -t {threads}
+                """
+	shell:
+		"""
+		mkdir -p {output.kma_dir}
 		kma -ipe {input.mate1} {input.mate2} -o {params.prefix} -t_db {params.db} -t {threads}
 		"""

--- a/workflow/rules/summarise_serovars.smk
+++ b/workflow/rules/summarise_serovars.smk
@@ -1,13 +1,15 @@
 rule summarize_serovars:
 	input:
-		kma_dir = expand(rules.detect_capsules.output.kma_dir, sample = samples)
+		assembly_results_dir = expand(rules.detect_assembly_capsules.output.kma_dir, sample = sample_assemblies),
+		assembly_results = expand(rules.detect_assembly_capsules.output.res_file, sample = sample_assemblies),
+		reads_results_dir = expand(rules.detect_reads_capsules.output.kma_dir, sample = sample_reads),
+		reads_results = expand(rules.detect_reads_capsules.output.res_file, sample = sample_reads)
 	params:
-		threshold_id = threshold_id,
-		threshold_cov = threshold_cov,
+		threshold = threshold,
 		metadata_file = metadata_file,
 		debug = debug
 	output:
-		serovar_file = "%s/Results/serovar.tsv" %outdir
+		serovar_file = "%s/serovar.tsv" %outdir
 	conda:
 		"../envs/R.yaml"
 	script:


### PR DESCRIPTION
Major update: Added a python launcher with integrated argument parser as well as a help page which can be envoked by executing . Apart from this, fasta file alongside read files are now fully supported. Metadata functionality still does not work, but it will be fixed later, alongside adding blackilisting support.