### PR TITLE
Fixed read sample pattern issue

### DIFF
--- a/serovar_detector.py
+++ b/serovar_detector.py
@@ -61,7 +61,7 @@ def screen_files(directory, type):
     read_files = fastqs + fqs
 
     # Search file names for metadata
-    pattern = "^(?P<file>\S+\/(?P<sample_name>\S+?)((_S\d+)?(_L\d+)?)?_(?P<mate>[Rr]?[12])(_\d{3})?\.(?P<ext>((fastq)?(fq)?)?(\.gz)?))"
+    pattern = "^(?P<file>\S+\/(?P<sample_name>\S+?)((_S\d+)(_L\d+))?_(?P<mate>[Rr]?[12])(_\d{3})?\.(?P<ext>((fastq)?(fq)?)?(\.gz)?))"
     search = [re.search(pattern, read_file) for read_file in read_files]
 
     # Generate DataFrame from search object groups


### PR DESCRIPTION
Changed the Read file search pattern, as it would miss sample names with _S\d+ (e.g. XYZ_S12345), as we have series and lane in our naming conventions, these are now expected to be in succession or they will not be sorted out