### PR TITLE
Galaxy conda support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ stashlist.txt
 slurm*
 .gitignore
 *.swp
+.DS_Store

--- a/serovar_detector.py
+++ b/serovar_detector.py
@@ -31,18 +31,18 @@ def validate_snakemake(debug):
 def generate_configfile(database, outdir, threshold, append_results, threads, debug, tmpdir):
   # Define config file
   config_file = "config/config.yaml"
-  
+
   # Check for existing config file
   if not os.path.isfile(config_file):
     config_dir = os.path.dirname(config_file)
-    
+
     # Check for existing config dir
     if not os.path.isdir(config_dir):
       print("No config dir detected, creating directory.")
       os.makedirs(config_dir)
 
   out_path = os.path.abspath(outdir).rstrip("/")
-  
+
   config = {
     "database": database, "outdir": out_path, "threshold": threshold,
     "append_results": append_results, "threads": threads, "debug": debug,
@@ -63,7 +63,7 @@ def screen_files(directory, type):
     read_files = fastqs + fqs
 
     # Search file names for metadata
-    pattern = "^(?P<file>\S+\/(?P<sample_name>\S+?)((_S\d+)(_L\d+))?_(?P<mate>[Rr]?[12])(_\d{3})?\.(?P<ext>((fastq)?(fq)?)?(\.gz)?))"
+    pattern = r"^(?P<file>\S+\/(?P<sample_name>\S+?)((_S\d+)(_L\d+))?_(?P<mate>[Rr]?[12])(_\d{3})?\.(?P<ext>((fastq)?(fq)?)?(\.gz)?))"
     search = [re.search(pattern, read_file) for read_file in read_files]
 
     # Generate DataFrame from search object groups
@@ -73,10 +73,10 @@ def screen_files(directory, type):
       "file": [search.group("file") for search in search],
       "type": type
     })
-    
+
     # Sort table
     metadata = metadata_raw.sort_values(by = ["sample_name", "mate"])
- 
+
   elif type == "Assembly":
     # Screen for files
     fastas = [sample_assembly for sample_assembly in glob.glob("%s/*.fasta" %directory)]
@@ -86,7 +86,7 @@ def screen_files(directory, type):
     assembly_files = fastas + fas
 
     # Search file names for metadata
-    pattern = "^(?P<file>\S+\/(?P<sample_name>\S+)\.(?P<ext>[fast]+))"
+    pattern = r"^(?P<file>\S+\/(?P<sample_name>\S+)\.(?P<ext>[fast]+))"
     search = [re.search(pattern, assembly_file) for assembly_file in assembly_files]
 
     # Generate DataFrame from search object groups
@@ -101,7 +101,7 @@ def screen_files(directory, type):
 
   else:
     return(pandas.DataFrame({"sample_name", "mate", "file", "type"}))
-  
+
   return(metadata) #file_metadata
 
 
@@ -126,7 +126,7 @@ def create_symlinks(metadata, outdir):
       # Ensuring outdir exists
       os.makedirs(name = f"{outdir}/assemblies", exist_ok = True)
 
-      # Defining input and output  
+      # Defining input and output
       sample_file = os.path.realpath(sample_metadata["file"])
       sample_link = f"{outdir}/assemblies/{sample_name}.fasta"
 
@@ -146,7 +146,7 @@ def make_sample_sheet(table):
   print("Generating sample sheet", end = "... ")
 
   file_count = len(table.index)
-  
+
   if file_count > 0:
     sample_subset = table[["sample_name", "type"]]
     sample_sheet = sample_subset.drop_duplicates()
@@ -168,7 +168,7 @@ def write_sample_sheet(sample_sheet, pepdir):
     print("Success: Overwritting %s" %sample_file)
   else:
     print("Success: Written to %s" %sample_file)
-    
+
 
 def write_subsample_sheet(subsample_sheet, pepdir):
   subsample_file = f"{pepdir}/subsample_sheet.csv"
@@ -187,23 +187,23 @@ def write_PEP(pepdir):
   # Define pep files
   pep_file = f"{pepdir}/project_config.yaml"
   pep_exists = os.path.exists(pep_file)
-  
+
   # Generate PEP configuration:
   PEP_header = "pep_version: 2.1.0\n"
   PEP_sample = "sample_table: 'sample_sheet.csv'\n"
   PEP_subsample = "subsample_table: 'subsample_sheet.csv'"
- 
+
   print("Writing project configuration file", end = "... ")
   with open(pep_file, "w") as config_file:
     config_file.write(PEP_header)
     config_file.write(PEP_sample)
     config_file.write(PEP_subsample)
-    
+
   if not pep_exists:
     print("Success: Written to %s" %pep_file)
   elif pep_exists:
     print("Success: Overwriting %s" %pep_file)
-  
+
 
 def generate_sheets(reads_dir, assembly_dir, enable_blacklist, blacklist_clean, outdir, blacklist_file, tmpdir):
   # Generating dirs
@@ -217,13 +217,13 @@ def generate_sheets(reads_dir, assembly_dir, enable_blacklist, blacklist_clean, 
   metadata = pandas.concat([reads_metadata, assembly_metadata], ignore_index = True, sort = True)
 
   # Inspect blacklist if enabled
-  blacklist_exists = os.path.exists(blacklist_file)  
+  blacklist_exists = os.path.exists(blacklist_file)
   if blacklist_exists:
     print("Blacklist file detected, reading!")
     blacklist = pandas.read_csv(blacklist_file, sep = "\t")
 
     exclude_samples = blacklist["file"].values
-  
+
     # Filter metadata
     metadata = metadata[~metadata["file"].isin(exclude_samples)].reset_index()
     if not enable_blacklist:
@@ -232,7 +232,7 @@ def generate_sheets(reads_dir, assembly_dir, enable_blacklist, blacklist_clean, 
   # Ensuring not all samples have been filtered out
   sample_size = len(metadata.index)
   if sample_size > 0:
-    
+
     # Generate symlinks
     create_symlinks(metadata, tmpdir)
 
@@ -241,7 +241,7 @@ def generate_sheets(reads_dir, assembly_dir, enable_blacklist, blacklist_clean, 
     pepdir_exists = os.path.isdir(pepdir)
 
     if not pepdir_exists:
-      os.makedirs(pepdir, exist_ok = True) 
+      os.makedirs(pepdir, exist_ok = True)
 
     sample_sheet = make_sample_sheet(metadata)
     sample_sheet_updated = write_sample_sheet(sample_sheet, pepdir)
@@ -277,9 +277,9 @@ def update_blacklist(enable_blacklist, blacklist_file, blacklist_clean, sample_f
       return(False)
   else:
       print("Created new blacklist file")
-   
+
   sample_files.to_csv(blacklist_file, sep = "\t", index=False, mode = mode, header = include_header)
-    
+
   return(True)
 
 
@@ -341,6 +341,7 @@ generate_configfile(database = database, outdir = outdir, threshold = threshold,
 # Generate subsample sheet
 sample_files = generate_sheets(reads_dir = reads_dir, assembly_dir = assembly_dir, enable_blacklist = enable_blacklist, blacklist_clean = blacklist_clean, outdir = outdir, blacklist_file = blacklist_file, tmpdir = tmpdir)
 
+
 if len(sample_files) == 0:
   print("Nothing to do exitting!")
   sys.exit(0)
@@ -351,7 +352,13 @@ if force or blacklist_clean:
 if dry_run:
   snake_args += " -n "
 
-snakemake_cmd = "snakemake --use-conda --cores %s%s" %(threads, snake_args) 
+# Use Snakemake's own conda envs only when explicitly requested. By default the
+# required tools (kma, R + packages, snakemake) are expected on PATH already
+# (e.g. provided by Galaxy's dependency resolver), so no per-run env building.
+# Set SEROVAR_DETECTOR_USE_CONDA=1 (or true/yes) to restore the old behaviour.
+_use_conda = os.environ.get("SEROVAR_DETECTOR_USE_CONDA", "").strip().lower() in ("1", "true", "yes")
+_conda_flag = "--use-conda " if _use_conda else ""
+snakemake_cmd = "snakemake %s--cores %s%s" %(_conda_flag, threads, snake_args)
 if debug:
   print("Running command: %s" %snakemake_cmd)
 

--- a/serovar_detector.py
+++ b/serovar_detector.py
@@ -56,8 +56,8 @@ def generate_configfile(database, outdir, threshold, append_results, threads, de
 def screen_files(directory, type):
   if type == "Reads":
     # Screen for files
-    fastqs = [sample_read for sample_read in glob.glob("%s/*.fastq*" %directory)]
-    fqs = [sample_read for sample_read in glob.glob("%s/*.fq*" %directory)]
+    fastqs = [sample_read for sample_read in glob.glob(f"{directory}/*.fastq*")]
+    fqs = [sample_read for sample_read in glob.glob(f"{directory}/*.fq*")]
 
     # Combine file lists
     read_files = fastqs + fqs
@@ -79,8 +79,8 @@ def screen_files(directory, type):
 
   elif type == "Assembly":
     # Screen for files
-    fastas = [sample_assembly for sample_assembly in glob.glob("%s/*.fasta" %directory)]
-    fas = [sample_assembly for sample_assembly in glob.glob("%s/*.fa" %directory)]
+    fastas = [sample_assembly for sample_assembly in glob.glob(f"{directory}/*.fasta")]
+    fas = [sample_assembly for sample_assembly in glob.glob(f"{directory}/*.fa")]
 
     # Combine file lists
     assembly_files = fastas + fas
@@ -154,7 +154,7 @@ def make_sample_sheet(table):
     print("Failed: Subsample sheet has no rows")
     sample_sheet = False
 
-  print("Success: A total of %s samples have been annotated!" %len(sample_sheet.index))
+  print(f"Success: A total of {len(sample_sheet.index)} samples have been annotated!")
   return(sample_sheet)
 
 
@@ -165,9 +165,9 @@ def write_sample_sheet(sample_sheet, pepdir):
   print("Writting sample sheet", end = "... ")
   sample_sheet.to_csv(sample_file, index = False)
   if sample_exists:
-    print("Success: Overwritting %s" %sample_file)
+    print(f"Success: Overwritting {sample_file}")
   else:
-    print("Success: Written to %s" %sample_file)
+    print(f"Success: Written to {sample_file}")
 
 
 def write_subsample_sheet(subsample_sheet, pepdir):
@@ -178,9 +178,9 @@ def write_subsample_sheet(subsample_sheet, pepdir):
   subsample_sheet.to_csv(subsample_file, index = False)
 
   if subsample_exists:
-    print("Success: Overwritting %s" %subsample_file)
+    print(f"Success: Overwritting {subsample_file}")
   else:
-    print("Success: Written to %s" %subsample_file)
+    print(f"Success: Written to {subsample_file}")
 
 
 def write_PEP(pepdir):
@@ -200,9 +200,9 @@ def write_PEP(pepdir):
     config_file.write(PEP_subsample)
 
   if not pep_exists:
-    print("Success: Written to %s" %pep_file)
+    print(f"Success: Written to {pep_file}")
   elif pep_exists:
-    print("Success: Overwriting %s" %pep_file)
+    print(f"Success: Overwriting {pep_file}")
 
 
 def generate_sheets(reads_dir, assembly_dir, enable_blacklist, blacklist_clean, outdir, blacklist_file, tmpdir):
@@ -287,15 +287,16 @@ def parse_arguments():
   parser = argparse.ArgumentParser(description = "Screen read files and assemblies for Serovar biomarker genes, in order to preovide suggestions for isolate serovar. Currently only supporting Actinobacillus Pleuropneumoniae.")
   parser.add_argument("-r", metavar = "--reads_dir", dest = "reads_dir", help = "Input path to reads directory", required = False)
   parser.add_argument("-a", metavar = "--assembly_dir", dest = "assembly_dir", help = "Input path to assembly directory", required = False)
-  parser.add_argument("-D", metavar = "--database", dest = "database", help = "Path and prefix to kmer-aligner database", default = "./db")
+  parser.add_argument("-D", metavar = "--database", dest = "database", help = "Path and prefix to kmer-aligner database", default = "./db/Actinobacillus_pleuropneumoniae")
   parser.add_argument("-o", metavar = "--outdir", dest = "outdir", help = "Output path to Results and Temporary files directory", required = True)
   parser.add_argument("-T", metavar = "--theshold", dest = "threshold", help = "Cutoff threshold of match coverage and identity. Ignore threshold by setting to 0 or False. (Default 98)", default = 98)
+  parser.add_argument("-t", metavar = "--threads", dest = "threads", help = "Number of threads to allocate for the pipeline. (Default 3)", default = 3)
   parser.add_argument("-R", dest = "append_results", help = "Append to existing results file. (Default False)", action = "store_true")
   parser.add_argument("-b", dest = "enable_blacklist", help = "Update existing blacklist file with new samples. Creates a blacklist file if non exists. (Default False)", action = "store_true")
   parser.add_argument("-B", dest = "blacklist_clean", help = "Ignore and overwrite existing blacklist file. Creates a blacklist if non exists. (Default False)", action = "store_true")
   parser.add_argument("-k", dest = "keep_tmp", help = "Preserve temporary files such as KMA result files. (Default False)", action = "store_true")
-  parser.add_argument("-t", metavar = "--threads", dest = "threads", help = "Number of threads to allocate for the pipeline. (Default 3)", default = 3)
   parser.add_argument("-F", dest = "force", help = "Force rerun of all tasks in pipeline. (Default False)", action = "store_true")
+  parser.add_argument("-c", dest = "noconda", help = "Don't let snakemake handle conda execution in rules. Enable this option if the pipeline should run in the current loaded environment. (Default False)", action = "store_true")
   parser.add_argument("-n", dest = "dry_run", help = "Perform a dry run with Snakemake to see jobs but without executing them. (Default False)", action = "store_true")
   parser.add_argument("-d", dest = "debug", help = "Enable debug mode, stores snakemake object for inspection in R. (Default False)", action = "store_true")
 
@@ -312,8 +313,9 @@ append_results = args.append_results
 enable_blacklist = args.enable_blacklist
 blacklist_clean = args.blacklist_clean
 keep_tmp = args.keep_tmp
-threads = args.threads
+threads = int(args.threads)
 force = args.force
+noconda = args.noconda
 dry_run = args.dry_run
 debug = args.debug
 tmpdir = f"{outdir}/tmp"
@@ -346,21 +348,18 @@ if len(sample_files) == 0:
   print("Nothing to do exitting!")
   sys.exit(0)
 
-snake_args = ""
+snake_args = f"--cores {threads} "
+if not noconda:
+  snake_args += "--use-conda "
 if force or blacklist_clean:
-  snake_args += " -F "
+  snake_args += "--forceall "
 if dry_run:
-  snake_args += " -n "
+  snake_args += "--dryrun "
 
-# Use Snakemake's own conda envs only when explicitly requested. By default the
-# required tools (kma, R + packages, snakemake) are expected on PATH already
-# (e.g. provided by Galaxy's dependency resolver), so no per-run env building.
-# Set SEROVAR_DETECTOR_USE_CONDA=1 (or true/yes) to restore the old behaviour.
-_use_conda = os.environ.get("SEROVAR_DETECTOR_USE_CONDA", "").strip().lower() in ("1", "true", "yes")
-_conda_flag = "--use-conda " if _use_conda else ""
-snakemake_cmd = "snakemake %s--cores %s%s" %(_conda_flag, threads, snake_args)
+
+snakemake_cmd = f"snakemake {snake_args}"
 if debug:
-  print("Running command: %s" %snakemake_cmd)
+  print(f"Executing: {snakemake_cmd}")
 
 
 results_file = f"{outdir}/serovar.tsv"

--- a/serovar_detector.py
+++ b/serovar_detector.py
@@ -381,4 +381,3 @@ else:
     shutil.rmtree(tmpdir)
 
   print("All Done!")
-


### PR DESCRIPTION
Also, I am submitting a conda receipe to Bioconda after you accept the PR. 

Add a license as well to your repo. 

## Summary

This pull request makes Snakemake's use of conda environments configurable and updates the filename-matching regular expressions to use raw Python strings.

## Changes

* Replace the unconditional Snakemake `--use-conda` option with the `SEROVAR_DETECTOR_USE_CONDA` environment variable.
* Run Snakemake without `--use-conda` by default.
* Enable `--use-conda` when `SEROVAR_DETECTOR_USE_CONDA` is set to `1`, `true`, or `yes`.
* Convert the FASTQ and FASTA filename regular-expression patterns to raw strings.

## Motivation

In managed environments such as Galaxy, the required dependencies may already be supplied by the active conda environment or Galaxy's dependency resolver.

Always passing `--use-conda` causes Snakemake to create or activate its own workflow environments, which can duplicate or conflict with the dependency management already provided by Galaxy.

This change allows Serovar Detector to use tools already available on `PATH` by default, while preserving the original Snakemake-managed conda behaviour as an explicit option.

## Usage

Default behaviour:

```bash
snakemake --cores <threads>
```

To enable Snakemake-managed conda environments:

```bash
export SEROVAR_DETECTOR_USE_CONDA=1
```

This produces:

```bash
snakemake --use-conda --cores <threads>
```

The values `true` and `yes` are also accepted.

## Compatibility

The original behaviour remains available through the environment variable, so users who rely on Snakemake's internal conda environments can continue using them.

## Testing

* Checked Python syntax with:

  ```bash
  python3 -m py_compile serovar_detector.py
  ```

* Verified command construction with and without `SEROVAR_DETECTOR_USE_CONDA`.

* Tested in a Galaxy environment where dependencies are supplied externally.
