### PR TITLE
Added labelling by comments and label validation check

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -1,0 +1,74 @@
+name: Label PR by Comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  version_labelling:
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Parse Command
+        id: parse
+        run: |
+          COMMENT_BODY="${{ github.event.comment.body }}"
+
+          if [[ "$COMMENT_BODY" == *"/minor"* ]]; then
+            echo "Attaching new label 'minor'"
+            echo "new_label=minor" >> $GITHUB_OUTPUT
+          elif [[ "$COMMENT_BODY" == *"/patch"* ]]; then
+            echo "Attaching new label 'patch'"
+            echo "new_label=patch" >> $GITHUB_OUTPUT
+          else:
+            echo "Comment is not rellated to version labelling"
+            exit 0
+          fi
+
+      - name: Authorize User
+        id: authorize
+        run: | 
+          COMMENTER="${{ github.event.comment.user.login }}"
+          PR_AUTHOR="${{ github.event.issue.user.login }}"
+          ASSOCIATION="${{ github.event.comment.author_association }}"
+          
+          echo "Commenter: $COMMENTER"
+          echo "PR Author: $PR_AUTHOR"
+          echo "Association: $ASSOCIATION"
+          
+          # Allow if commenter is the PR author, the repo owner, or a collaborator
+          if [ "$COMMENTER" = "$PR_AUTHOR" ] || [ "$ASSOCIATION" = "OWNER" ] || [ "$ASSOCIATION" = "COLLABORATOR" ] || [ "$ASSOCIATION" = "MEMBER" ]; then
+            echo "Labelling comment authorized" 
+            echo "authorized=true" >> $GITHUB_OUTPUT
+          else
+            echo "User not authorized to update version labels."
+            echo "authorized=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update Labels
+        if: steps.authorize.output.authorized == "true" && steps.parse.outputs.new_label != ""
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          NEW_LABEL: ${{ steps.parse.output.new_label }}
+        run: |
+          CURRENT_LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')
+
+          # Define conflicting versioning labels
+          VERSION_LABELS=("major" "minor" "patch")
+
+          # Loop through current labels and remove any conflicting version labels
+          for label in $CURRENT_LABELS; do
+            if [[ " ${VERSION_LABELS[@]} " =~ " ${label} " ]]; then
+              echo "Removing old label: $label"
+              gh pr edit "$PR_NUMBER" --remove-label "$label"
+            fi
+          done
+
+          # Apply the requested new label
+          echo "Adding new label: $NEW_LABEL"
+          gh pr edit "$PR_NUMBER" --add-label "$NEW_LABEL"

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -9,6 +9,7 @@ jobs:
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     permissions:
+      issues: write
       pull-requests: write
 
     steps:
@@ -16,18 +17,16 @@ jobs:
         id: parse
         run: |
           COMMENT_BODY="${{ github.event.comment.body }}"
-
           if [[ "$COMMENT_BODY" == *"/minor"* ]]; then
             echo "Attaching new label 'minor'"
             echo "new_label=minor" >> $GITHUB_OUTPUT
           elif [[ "$COMMENT_BODY" == *"/patch"* ]]; then
             echo "Attaching new label 'patch'"
             echo "new_label=patch" >> $GITHUB_OUTPUT
-          else:
-            echo "Comment is not rellated to version labelling"
+          else
+            echo "Comment is not related to version labelling"
             exit 0
           fi
-
       - name: Authorize User
         id: authorize
         run: | 
@@ -47,20 +46,19 @@ jobs:
             echo "User not authorized to update version labels."
             echo "authorized=false" >> $GITHUB_OUTPUT
           fi
-
       - name: Update Labels
-        if: steps.authorize.output.authorized == "true" && steps.parse.outputs.new_label != ""
+        # FIXED: Changed double quotes to single quotes, and output to outputs
+        if: steps.authorize.outputs.authorized == 'true' && steps.parse.outputs.new_label != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
-          NEW_LABEL: ${{ steps.parse.output.new_label }}
+          # FIXED: Changed step.parse.output to steps.parse.outputs
+          NEW_LABEL: ${{ steps.parse.outputs.new_label }}
         run: |
           CURRENT_LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')
-
           # Define conflicting versioning labels
           VERSION_LABELS=("major" "minor" "patch")
-
           # Loop through current labels and remove any conflicting version labels
           for label in $CURRENT_LABELS; do
             if [[ " ${VERSION_LABELS[@]} " =~ " ${label} " ]]; then
@@ -68,7 +66,6 @@ jobs:
               gh pr edit "$PR_NUMBER" --remove-label "$label"
             fi
           done
-
           # Apply the requested new label
           echo "Adding new label: $NEW_LABEL"
           gh pr edit "$PR_NUMBER" --add-label "$NEW_LABEL"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,47 @@
+name: Validate PR Labels
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  check-version-label:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Validate Single Version Label
+        run: |
+          PR_NUM="${{ github.event.pull_request.number }}"
+          REPO="${{ github.repository }}"
+          
+          echo "Checking labels for PR #$PR_NUM in $REPO..."
+          
+          # Fetch all current labels on the PR as a line-separated list
+          CURRENT_LABELS=$(gh pr view "$PR_NUM" -R "$REPO" --json labels --jq '.labels[].name')
+          
+          # Count how many of the required version labels are currently applied
+          MATCH_COUNT=0
+          FOUND_LABELS=()
+          
+          for label in $CURRENT_LABELS; do
+            if [[ "$label" == "major" || "$label" == "minor" || "$label" == "patch" ]]; then
+              MATCH_COUNT=$((MATCH_COUNT + 1))
+              FOUND_LABELS+=("$label")
+            fi
+          done
+          
+          echo "Found version labels: ${FOUND_LABELS[*]}"
+          echo "Total count: $MATCH_COUNT"
+          
+          # Enforce the "exactly one" ruleset
+          if [ "$MATCH_COUNT" -eq 1 ]; then
+            echo "Success: Exactly one versioning label is applied (${FOUND_LABELS[0]})."
+            exit 0
+          elif [ "$MATCH_COUNT" -eq 0 ]; then
+            echo "Error: Pull Request is missing a version label (major, minor, or patch)."
+            exit 1
+          else
+            echo "Error: Pull Request has multiple version labels (${FOUND_LABELS[*]}). Only one is allowed."
+            exit 1
+          fi


### PR DESCRIPTION
* PR's can now be labelled minor or patch by the PR author or repo collaborators by issuing a comment of "/minor" OR "/patch"
* PR's are checked for correct version labelling